### PR TITLE
chore: initialize web app skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+node_modules
+.next
+out
+build
+coverage
+dist
+.env.local
+.env
+*.log
+.DS_Store
+# Lockfiles
+package-lock.json
+yarn.lock
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# portfolio-v1
+# Portfolio v1
+
+## Setup
+
+```sh
+npm install
+```
+
+## TODO
+
+- Initialize shadcn/ui: `npx shadcn-ui@latest init` inside `apps/web`.
+- Add logo and other assets in `apps/web/public`.
+
+## Assumptions
+
+- Uses npm and Node.js 18+.

--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["next/core-web-vitals", "prettier"]
+};

--- a/apps/web/.prettierrc
+++ b/apps/web/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "printWidth": 80,
+  "trailingComma": "es5"
+}

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <section className="p-4">
+      <h1 className="text-2xl font-bold text-primary-900">Hello</h1>
+      <p className="text-primary-700">Welcome to my portfolio.</p>
+    </section>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,19 @@
+import "../styles/globals.css";
+import type { ReactNode } from "react";
+import { Analytics } from "../lib/analytics";
+
+export const metadata = {
+  title: "Portfolio",
+  description: "Personal portfolio."
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        <Analytics />
+      </body>
+    </html>
+  );
+}

--- a/apps/web/lib/analytics.ts
+++ b/apps/web/lib/analytics.ts
@@ -1,0 +1,3 @@
+export function Analytics() {
+  return null; // TODO: add analytics provider
+}

--- a/apps/web/lib/seo.ts
+++ b/apps/web/lib/seo.ts
@@ -1,0 +1,11 @@
+export const defaultSeo = {
+  title: "Portfolio",
+  description: "Personal portfolio"
+};
+
+export function getMeta(options?: { title?: string; description?: string }) {
+  return {
+    title: options?.title ?? defaultSeo.title,
+    description: options?.description ?? defaultSeo.description
+  };
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "web",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "autoprefixer": "latest",
+    "eslint": "latest",
+    "eslint-config-next": "latest",
+    "postcss": "latest",
+    "prettier": "latest",
+    "tailwindcss": "latest",
+    "typescript": "latest"
+  }
+}

--- a/apps/web/postcss.config.mjs
+++ b/apps/web/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/web/public/README_ASSETS.md
+++ b/apps/web/public/README_ASSETS.md
@@ -1,0 +1,3 @@
+# Assets
+
+TODO: Add logo and other static assets here.

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -1,0 +1,16 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --color-primary-900: #16697A;
+  --color-primary-700: #489FB5;
+  --color-primary-500: #82C0CC;
+  --color-primary-100: #EDE7E3;
+  --color-accent: #FFA62B;
+}
+
+body {
+  background-color: var(--color-primary-100);
+  color: var(--color-primary-900);
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,25 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          900: "var(--color-primary-900)",
+          700: "var(--color-primary-700)",
+          500: "var(--color-primary-500)",
+          100: "var(--color-primary-100)"
+        },
+        accent: "var(--color-accent)"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node"],
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "portfolio-v1",
+  "private": true,
+  "workspaces": ["apps/web"],
+  "scripts": {
+    "dev": "turbo dev --filter=web",
+    "build": "turbo build --filter=web",
+    "lint": "turbo lint --filter=web",
+    "test": "echo \"No tests yet\""
+  },
+  "devDependencies": {
+    "turbo": "latest"
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**"]
+    },
+    "lint": {},
+    "dev": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js app with TypeScript and Tailwind in `apps/web`
- define shared color palette and basic home page
- add placeholders for SEO, analytics, and assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af00e4c2908332a83140eaa9f8d4e3